### PR TITLE
TypeError при работе с ArrayIterator в PHP 7.4

### DIFF
--- a/src/LTDBeget/stringstream/StringStream.php
+++ b/src/LTDBeget/stringstream/StringStream.php
@@ -32,9 +32,8 @@ class StringStream
      * Current char of stream
      * @return string|null
      */
-    public function current() : ?string
+    public function current()
     {
-        //return current($this->stream);
         return $this->stream->current();
     }
 
@@ -72,8 +71,6 @@ class StringStream
     public function next()
     {
         $this->pointerAtStart = false;
-
-        //var_dump($this->stream->key() . " - " . $this->stream->count());
         if ($this->stream->key() === $this->stream->count() - 1) {
             $this->pointerAtEnd = true;
         } else {
@@ -88,8 +85,6 @@ class StringStream
     public function previous()
     {
         $this->pointerAtEnd = false;
-        // $this->pointerAtStart = prev($this->stream) === false;
-
         $this->pointerAtStart = false;
         if ($this->stream->key() == 0) {
             $this->pointerAtStart = true;
@@ -104,7 +99,6 @@ class StringStream
      */
     public function start()
     {
-        //reset($this->stream);
         $this->stream->rewind();
     }
 
@@ -122,7 +116,6 @@ class StringStream
      */
     public function end()
     {
-        //end($this->stream);
         $this->stream->seek($this->stream->count() - 1);
     }
 

--- a/src/LTDBeget/stringstream/StringStream.php
+++ b/src/LTDBeget/stringstream/StringStream.php
@@ -30,11 +30,12 @@ class StringStream
 
     /**
      * Current char of stream
-     * @return string
+     * @return string|null
      */
-    public function current() : string
+    public function current() : ?string
     {
-        return current($this->stream);
+        //return current($this->stream);
+        return $this->stream->current();
     }
 
     /**
@@ -62,7 +63,7 @@ class StringStream
      */
     public function position() : int
     {
-        return key($this->stream);
+        return $this->stream->key();
     }
 
     /**
@@ -71,7 +72,14 @@ class StringStream
     public function next()
     {
         $this->pointerAtStart = false;
-        $this->pointerAtEnd = next($this->stream) === false;
+
+        //var_dump($this->stream->key() . " - " . $this->stream->count());
+        if ($this->stream->key() === $this->stream->count() - 1) {
+            $this->pointerAtEnd = true;
+        } else {
+            $this->pointerAtEnd = false;
+            $this->stream->next();
+        }
     }
 
     /**
@@ -80,7 +88,15 @@ class StringStream
     public function previous()
     {
         $this->pointerAtEnd = false;
-        $this->pointerAtStart = prev($this->stream) === false;
+        // $this->pointerAtStart = prev($this->stream) === false;
+
+        $this->pointerAtStart = false;
+        if ($this->stream->key() == 0) {
+            $this->pointerAtStart = true;
+        } else {
+            $prevPos = $this->stream->key() - 1;
+            $this->stream->seek($prevPos);
+        }
     }
 
     /**
@@ -88,7 +104,8 @@ class StringStream
      */
     public function start()
     {
-        reset($this->stream);
+        //reset($this->stream);
+        $this->stream->rewind();
     }
 
     /**
@@ -105,7 +122,8 @@ class StringStream
      */
     public function end()
     {
-        end($this->stream);
+        //end($this->stream);
+        $this->stream->seek($this->stream->count() - 1);
     }
 
     /**
@@ -169,7 +187,7 @@ class StringStream
     }
 
     /**
-     * @var array
+     * @var ArrayIterator
      */
     private $stream;
 


### PR DESCRIPTION
Добрая ночь, в PHP 7.4 старые функции для итерации стали падать с TypeError при работе с ArrayIterator. Пользуемся на работе вашим токенайзером для Сфинкса, так что взялись оперативно поправить