### PR TITLE
Add support PHP 7.4

### DIFF
--- a/src/LTDBeget/stringstream/StringStream.php
+++ b/src/LTDBeget/stringstream/StringStream.php
@@ -34,7 +34,7 @@ class StringStream
      */
     public function current() : string
     {
-        return current($this->stream);
+        return $this->stream->current();
     }
 
     /**
@@ -62,7 +62,7 @@ class StringStream
      */
     public function position() : int
     {
-        return key($this->stream);
+        return $this->stream->key();
     }
 
     /**
@@ -71,7 +71,12 @@ class StringStream
     public function next()
     {
         $this->pointerAtStart = false;
-        $this->pointerAtEnd = next($this->stream) === false;
+        if ($this->stream->key() === $this->stream->count() - 1) {
+            $this->pointerAtEnd = true;
+        } else {
+            $this->pointerAtEnd = false;
+            $this->stream->next();
+        }
     }
 
     /**
@@ -80,7 +85,12 @@ class StringStream
     public function previous()
     {
         $this->pointerAtEnd = false;
-        $this->pointerAtStart = prev($this->stream) === false;
+        if ($this->stream->key() == 0) {
+            $this->pointerAtStart = true;
+        } else {
+            $this->pointerAtStart = false;
+            $this->stream->seek($this->stream->key() - 1);
+        }
     }
 
     /**
@@ -88,7 +98,7 @@ class StringStream
      */
     public function start()
     {
-        reset($this->stream);
+        $this->stream->rewind();
     }
 
     /**
@@ -105,7 +115,7 @@ class StringStream
      */
     public function end()
     {
-        end($this->stream);
+        $this->stream->seek($this->stream->count() - 1);
     }
 
     /**
@@ -169,7 +179,7 @@ class StringStream
     }
 
     /**
-     * @var array
+     * @var ArrayIterator
      */
     private $stream;
 


### PR DESCRIPTION
Привет, в PHP 7.4 падает с TypeError из-за работы с ArrayIterator как обычным массивом.
Поменял функции массивов на методы ArrayIterator.
Тесты sphinx-configuration-tokenizer проходят.